### PR TITLE
fix: include `stddef.h` in generated C code

### DIFF
--- a/out/can_handlers.h
+++ b/out/can_handlers.h
@@ -3,7 +3,7 @@
 #define CAN_HANDLERS_H
 
 #include <stdint.h>
-
+#include <stddef.h>
 /**
  * @brief   Entry in CAN handler table
  */


### PR DESCRIPTION

### Changes
- Add stddef.h linking

### Additional Notes
Any additional notes.
