### PR TITLE
fix: add `stddef.h` to C code generation

### DIFF
--- a/tsgen/__main__.py
+++ b/tsgen/__main__.py
@@ -101,6 +101,7 @@ class TelemetrySystemGenerator:
                 #define CAN_HANDLERS_H
 
                 #include <stdint.h>
+                #include <stddef.h>
 
                 /**
                  * @brief   Entry in CAN handler table


### PR DESCRIPTION
### Changes
- Does the actual fix for #9 