### PR TITLE
Feat/r2d pump lockout

### DIFF
--- a/out/can_s.c
+++ b/out/can_s.c
@@ -1032,3 +1032,19 @@ bool can_s_vcu_error_vcu_canbc_error_is_in_range(uint8_t value)
 
     return (true);
 }
+
+int can_s_vcu_pdm_voltage_out_unpack(
+    struct can_s_vcu_pdm_voltage_out *vout,
+    const uint8_t *src_p,
+    size_t size)
+{
+    if (size && src_p[0] == 1)
+    {
+        if (size > 5) {
+            vout->pdm_output_4_voltage = src_p[4];
+            vout->pdm_output_5_voltage = src_p[5];
+        }
+    }
+
+    return 0;
+}

--- a/out/can_s.c
+++ b/out/can_s.c
@@ -1034,15 +1034,15 @@ bool can_s_vcu_error_vcu_canbc_error_is_in_range(uint8_t value)
 }
 
 int can_s_vcu_pdm_voltage_out_unpack(
-    struct can_s_vcu_pdm_voltage_out *vout,
+    struct can_s_vcu_pdm_voltage_out *dst_p,
     const uint8_t *src_p,
     size_t size)
 {
-    if (size && src_p[0] == 1)
+    if (size && src_p[0] == 0)
     {
         if (size > 5) {
-            vout->pdm_output_4_voltage = src_p[4]/5;
-            vout->pdm_output_5_voltage = src_p[5]/5;
+            dst_p->pdm_output_4_voltage = src_p[4]/5;
+            dst_p->pdm_output_5_voltage = src_p[5]/5;
         }
     }
 

--- a/out/can_s.c
+++ b/out/can_s.c
@@ -922,6 +922,27 @@ int can_s_vcu_error_unpack(
     return (0);
 }
 
+int can_s_msgid_0_x201_unpack(
+    struct can_s_msgid_0_x201_t *dst_p,
+    const uint8_t *src_p,
+    size_t size)
+{
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    dst_p->bms_pack_current = unpack_left_shift_u16(src_p[0], 8u, 0xffu);
+    dst_p->bms_pack_current |= unpack_right_shift_u16(src_p[1], 0u, 0xffu);
+    dst_p->bms_pack_inst_voltage = unpack_left_shift_u16(src_p[2], 8u, 0xffu);
+    dst_p->bms_pack_inst_voltage |= unpack_right_shift_u16(src_p[3], 0u, 0xffu);
+    dst_p->bms_pack_soc = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
+    dst_p->bms_maximum_pack_voltage = unpack_right_shift_u8(src_p[5], 0u, 0xffu);
+    dst_p->bms_minimum_pack_voltage = unpack_right_shift_u8(src_p[6], 0u, 0xffu);
+    dst_p->bms_total_pack_cycles = unpack_right_shift_u8(src_p[7], 0u, 0xffu);
+
+    return (0);
+}
+
 int can_s_vcu_error_init(struct can_s_vcu_error_t *msg_p)
 {
     if (msg_p == NULL) return -1;

--- a/out/can_s.c
+++ b/out/can_s.c
@@ -1033,18 +1033,72 @@ bool can_s_vcu_error_vcu_canbc_error_is_in_range(uint8_t value)
     return (true);
 }
 
-int can_s_vcu_pdm_voltage_out_unpack(
-    struct can_s_vcu_pdm_voltage_out *dst_p,
+int can_s_pdm_out_voltage_unpack(
+    struct can_s_pdm_out_voltage_t *dst_p,
     const uint8_t *src_p,
     size_t size)
 {
-    if (size && src_p[0] == 0)
-    {
-        if (size > 5) {
-            dst_p->pdm_output_4_voltage = src_p[4]/5;
-            dst_p->pdm_output_5_voltage = src_p[5]/5;
-        }
+    uint8_t pdm_out_voltage_compound_id;
+
+    if (size < 8u) {
+        return (-EINVAL);
     }
 
-    return 0;
+    pdm_out_voltage_compound_id = unpack_right_shift_u8(src_p[0], 0u, 0xffu);
+    dst_p->pdm_out_voltage_compound_id = (int8_t)pdm_out_voltage_compound_id;
+
+    switch (dst_p->pdm_out_voltage_compound_id) {
+
+    case 0:
+        dst_p->pdm_output_1_voltage = unpack_right_shift_u8(src_p[1], 0u, 0xffu);
+        dst_p->pdm_output_2_voltage = unpack_right_shift_u8(src_p[2], 0u, 0xffu);
+        dst_p->pdm_output_3_voltage = unpack_right_shift_u8(src_p[3], 0u, 0xffu);
+        dst_p->pdm_output_4_voltage = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
+        dst_p->pdm_output_5_voltage = unpack_right_shift_u8(src_p[5], 0u, 0xffu);
+        dst_p->pdm_output_6_voltage = unpack_right_shift_u8(src_p[6], 0u, 0xffu);
+        dst_p->pdm_output_7_voltage = unpack_right_shift_u8(src_p[7], 0u, 0xffu);
+        break;
+
+    case 1:
+        dst_p->pdm_output_8_voltage = unpack_right_shift_u8(src_p[1], 0u, 0xffu);
+        dst_p->pdm_output_9_voltage = unpack_right_shift_u8(src_p[2], 0u, 0xffu);
+        dst_p->pdm_output_10_voltage = unpack_right_shift_u8(src_p[3], 0u, 0xffu);
+        dst_p->pdm_output_11_voltage = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
+        dst_p->pdm_output_12_voltage = unpack_right_shift_u8(src_p[5], 0u, 0xffu);
+        dst_p->pdm_output_13_voltage = unpack_right_shift_u8(src_p[6], 0u, 0xffu);
+        dst_p->pdm_output_14_voltage = unpack_right_shift_u8(src_p[7], 0u, 0xffu);
+        break;
+
+    case 2:
+        dst_p->pdm_output_15_voltage = unpack_right_shift_u8(src_p[1], 0u, 0xffu);
+        dst_p->pdm_output_16_voltage = unpack_right_shift_u8(src_p[2], 0u, 0xffu);
+        dst_p->pdm_output_17_voltage = unpack_right_shift_u8(src_p[3], 0u, 0xffu);
+        dst_p->pdm_output_18_voltage = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
+        dst_p->pdm_output_19_voltage = unpack_right_shift_u8(src_p[5], 0u, 0xffu);
+        dst_p->pdm_output_20_voltage = unpack_right_shift_u8(src_p[6], 0u, 0xffu);
+        dst_p->pdm_output_21_voltage = unpack_right_shift_u8(src_p[7], 0u, 0xffu);
+        break;
+
+    case 3:
+        dst_p->pdm_output_22_voltage = unpack_right_shift_u8(src_p[1], 0u, 0xffu);
+        dst_p->pdm_output_23_voltage = unpack_right_shift_u8(src_p[2], 0u, 0xffu);
+        dst_p->pdm_output_24_voltage = unpack_right_shift_u8(src_p[3], 0u, 0xffu);
+        dst_p->pdm_output_25_voltage = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
+        dst_p->pdm_output_26_voltage = unpack_right_shift_u8(src_p[5], 0u, 0xffu);
+        dst_p->pdm_output_27_voltage = unpack_right_shift_u8(src_p[6], 0u, 0xffu);
+        dst_p->pdm_output_28_voltage = unpack_right_shift_u8(src_p[7], 0u, 0xffu);
+        break;
+
+    case 4:
+        dst_p->pdm_output_29_voltage = unpack_right_shift_u8(src_p[1], 0u, 0xffu);
+        dst_p->pdm_output_30_voltage = unpack_right_shift_u8(src_p[2], 0u, 0xffu);
+        dst_p->pdm_output_31_voltage = unpack_right_shift_u8(src_p[3], 0u, 0xffu);
+        dst_p->pdm_output_32_voltage = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
+        break;
+
+    default:
+        break;
+    }
+
+    return (0);
 }

--- a/out/can_s.c
+++ b/out/can_s.c
@@ -1041,8 +1041,8 @@ int can_s_vcu_pdm_voltage_out_unpack(
     if (size && src_p[0] == 1)
     {
         if (size > 5) {
-            vout->pdm_output_4_voltage = src_p[4];
-            vout->pdm_output_5_voltage = src_p[5];
+            vout->pdm_output_4_voltage = src_p[4]/5;
+            vout->pdm_output_5_voltage = src_p[5]/5;
         }
     }
 

--- a/out/can_s.h
+++ b/out/can_s.h
@@ -54,6 +54,7 @@ extern "C" {
 #define CAN_S_VCU_STATE_FRAME_ID (0x101u)
 #define CAN_S_VCU_ERROR_FRAME_ID (0x102u)
 #define CAN_S_VCU_TEMPS_FRAME_ID (0x105u)
+#define CAN_S_VCU_PDM_OUT_VOLTAGE_FRAME_ID (0x503u)
 
 /* Frame lengths in bytes. */
 #define CAN_S_OCT_GPS_STATS_LENGTH (8u)

--- a/out/can_s.h
+++ b/out/can_s.h
@@ -54,6 +54,7 @@ extern "C" {
 #define CAN_S_VCU_STATE_FRAME_ID (0x101u)
 #define CAN_S_VCU_ERROR_FRAME_ID (0x102u)
 #define CAN_S_VCU_TEMPS_FRAME_ID (0x105u)
+#define CAN_S_MSGID_0_X201_FRAME_ID (0x201u)
 
 /* Frame lengths in bytes. */
 #define CAN_S_OCT_GPS_STATS_LENGTH (8u)
@@ -408,6 +409,57 @@ struct can_s_vcu_error_t {
      * Offset: 0
      */
     uint8_t vcu_canbc_error;
+};
+
+/**
+ * Signals in message MSGID_0X201.
+ *
+ * This ID Transmits at 8 ms.
+ *
+ * All signal values are as on the CAN bus.
+ */
+struct can_s_msgid_0_x201_t {
+    /**
+     * Range: -
+     * Scale: 0.1
+     * Offset: 0
+     */
+    uint16_t bms_pack_current;
+
+    /**
+     * Range: -
+     * Scale: 0.1
+     * Offset: 0
+     */
+    uint16_t bms_pack_inst_voltage;
+
+    /**
+     * Range: -
+     * Scale: 0.5
+     * Offset: 0
+     */
+    uint8_t bms_pack_soc;
+
+    /**
+     * Range: -
+     * Scale: 0.1
+     * Offset: 0
+     */
+    uint8_t bms_maximum_pack_voltage;
+
+    /**
+     * Range: -
+     * Scale: 0.1
+     * Offset: 0
+     */
+    uint8_t bms_minimum_pack_voltage;
+
+    /**
+     * Range: -
+     * Scale: 1
+     * Offset: 1721
+     */
+    uint8_t bms_total_pack_cycles;
 };
 
 /**
@@ -1536,6 +1588,19 @@ double can_s_vcu_error_vcu_canbc_error_decode(uint8_t value);
  */
 bool can_s_vcu_error_vcu_canbc_error_is_in_range(uint8_t value);
 
+/**
+ * Unpack message MSGID_0X201.
+ *
+ * @param[out] dst_p Object to unpack the message into.
+ * @param[in] src_p Message to unpack.
+ * @param[in] size Size of src_p.
+ *
+ * @return zero(0) or negative error code.
+ */
+int can_s_msgid_0_x201_unpack(
+    struct can_s_msgid_0_x201_t *dst_p,
+    const uint8_t *src_p,
+    size_t size);
 
 #ifdef __cplusplus
 }

--- a/out/can_s.h
+++ b/out/can_s.h
@@ -54,7 +54,7 @@ extern "C" {
 #define CAN_S_VCU_STATE_FRAME_ID (0x101u)
 #define CAN_S_VCU_ERROR_FRAME_ID (0x102u)
 #define CAN_S_VCU_TEMPS_FRAME_ID (0x105u)
-#define CAN_S_VCU_PDM_OUT_VOLTAGE_FRAME_ID (0x503u)
+#define CAN_S_PDM_OUT_VOLTAGE_FRAME_ID (0x503u)
 
 /* Frame lengths in bytes. */
 #define CAN_S_OCT_GPS_STATS_LENGTH (8u)
@@ -411,22 +411,242 @@ struct can_s_vcu_error_t {
     uint8_t vcu_canbc_error;
 };
 
-struct can_s_vcu_pdm_voltage_out {
+/**
+ * Signals in message PDM_Out_Voltage.
+ *
+ * All signal values are as on the CAN bus.
+ */
+struct can_s_pdm_out_voltage_t {
     /**
-     * Range: 0..255 (0..255 -)
+     * Range: -
+     * Scale: 1
+     * Offset: 0
+     */
+    int8_t pdm_out_voltage_compound_id;
+
+    /**
+     * Range: 0..255 (0..51 V)
      * Scale: 0.2
      * Offset: 0
-     * Unit: V
+     */
+    uint8_t pdm_output_8_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_29_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_22_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_1_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_15_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_9_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_30_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_2_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_23_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_16_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_3_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_31_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_24_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_17_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_10_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
      */
     uint8_t pdm_output_4_voltage;
 
     /**
-     * Range: 0..255 (0..255 -)
+     * Range: 0..255 (0..51 V)
      * Scale: 0.2
      * Offset: 0
-     * Unit: V
+     */
+    uint8_t pdm_output_32_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_25_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_18_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_11_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
      */
     uint8_t pdm_output_5_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_26_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_19_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_12_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_6_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_27_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_20_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_13_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_7_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_28_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_21_voltage;
+
+    /**
+     * Range: 0..255 (0..51 V)
+     * Scale: 0.2
+     * Offset: 0
+     */
+    uint8_t pdm_output_14_voltage;
 };
 
 /**
@@ -1565,8 +1785,8 @@ bool can_s_vcu_error_vcu_canbc_error_is_in_range(uint8_t value);
  *
  * @return zero(0) or negative error code.
  */
-int can_s_vcu_pdm_voltage_out_unpack(
-    struct can_s_vcu_pdm_voltage_out *vout,
+int can_s_pdm_out_voltage_unpack(
+    struct can_s_pdm_out_voltage_t *dst_p,
     const uint8_t *src_p,
     size_t size);
 

--- a/out/can_s.h
+++ b/out/can_s.h
@@ -411,6 +411,24 @@ struct can_s_vcu_error_t {
     uint8_t vcu_canbc_error;
 };
 
+struct can_s_vcu_pdm_voltage_out {
+    /**
+     * Range: 0..255 (0..255 -)
+     * Scale: 0.2
+     * Offset: 0
+     * Unit: V
+     */
+    uint8_t pdm_output_4_voltage;
+
+    /**
+     * Range: 0..255 (0..255 -)
+     * Scale: 0.2
+     * Offset: 0
+     * Unit: V
+     */
+    uint8_t pdm_output_5_voltage;
+};
+
 /**
  * Pack message OCT_GPS_Stats.
  *
@@ -1537,6 +1555,20 @@ double can_s_vcu_error_vcu_canbc_error_decode(uint8_t value);
  */
 bool can_s_vcu_error_vcu_canbc_error_is_in_range(uint8_t value);
 
+
+/**
+ * Unpack message PDM_Out_Voltage.
+ *
+ * @param[out] dst_p Object to unpack the message into.
+ * @param[in] src_p Message to unpack.
+ * @param[in] size Size of src_p.
+ *
+ * @return zero(0) or negative error code.
+ */
+int can_s_vcu_pdm_voltage_out_unpack(
+    struct can_s_vcu_pdm_voltage_out *vout,
+    const uint8_t *src_p,
+    size_t size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Changes

- Manually added CAN_S_VCU_PDM_OUT_VOLTAGE_FRAME_ID

### Fixed Issue(s)

Required to solve [vcu#238](https://github.com/sufst/vcu/issues/238)

### Checklist

- ~~Schemas are generated with no errors.~~ N/A - manual edit
- [X] ~~`/out` folder has not been changed, or~~ this is a new release.
- [X] If modified, the DBC file(s) can be opened in Vector CANdb++ without issue. - not modified
