### PR TITLE
Feat/vcu power save mode

### DIFF
--- a/dbc/CAN-S.dbc
+++ b/dbc/CAN-S.dbc
@@ -350,7 +350,7 @@ BO_ 256 VCU_Sensors: 8 VCU
  SG_ VCU_APPS : 0|16@1+ (0.1,0) [0|100] "%" Vector__XXX
 
 BO_ 257 VCU_State: 4 VCU
- SG_ VCU_Power_Saving : 27|1@1- (1,0) [0|1] "" Vector__XXX
+ SG_ VCU_Power_Saving : 27|1@1+ (1,0) [0|1] "" Vector__XXX
  SG_ VCU_Rolling_Counter : 0|16@1+ (1,0) [0|65535] "" Vector__XXX
  SG_ VCU_DRS_Allowed : 26|1@1+ (1,0) [0|1] "" Vector__XXX
  SG_ VCU_DRS_Active : 25|1@1+ (1,0) [0|1] "" Vector__XXX

--- a/dbc/CAN-S.dbc
+++ b/dbc/CAN-S.dbc
@@ -43,9 +43,18 @@ BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
  SG_ OCT_GPS_Longitude : 0|32@1- (0.0001,0) [0|1809999999] "" Vector__XXX
  SG_ OCT_GPS_Latitude : 0|31@1- (0.0001,0) [0|909999999] "" Vector__XXX
 
+BO_ 262 VCU_Simulation: 8 Vector__XXX
+ SG_ VCU_Sim_Torque_Request m0 : 40|16@1+ (0.1,0) [0|6553.5] "Nm" Vector__XXX
+ SG_ VCU_Sim_Power m1 : 8|16@1+ (0.2,0) [0|13107] "W" Vector__XXX
+ SG_ VCU_Simulation_MUX M : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ VCU_Sim_BPS m0 : 24|16@1+ (0.1,0) [0|100] "%" Vector__XXX
+ SG_ VCU_Sim_APPS m0 : 8|16@1+ (0.1,0) [0|100] "%" Vector__XXX
+ SG_ VCU_Sim_TS_ON m0 : 57|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ VCU_Sim_R2D m0 : 56|1@1+ (1,0) [0|1] "" Vector__XXX
+
 BO_ 1536 CAN_NODE_0: 8 CAN_NODE_0
- SG_ CAN_NODE_THERM_2 m2 : 16|8@1- (1,0) [-128|127] "°C" Vector__XXX
- SG_ CAN_NODE_THERM_1 m2 : 8|8@1- (1,0) [-128|127] "°C" Vector__XXX
+ SG_ CAN_NODE_THERM_2 m2 : 16|8@1- (1,0) [-128|127] "ï¿½C" Vector__XXX
+ SG_ CAN_NODE_THERM_1 m2 : 8|8@1- (1,0) [-128|127] "ï¿½C" Vector__XXX
  SG_ CAN_NODE_PD_9 m1 : 40|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
  SG_ CAN_NODE_PD_8 m1 : 28|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
  SG_ CAN_NODE_PD_7 m1 : 16|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
@@ -59,8 +68,8 @@ BO_ 1536 CAN_NODE_0: 8 CAN_NODE_0
  SG_ CAN_NODE_multiplexor M : 0|4@1+ (1,0) [0|15] "" Vector__XXX
 
 BO_ 1537 CAN_NODE_1: 8 CAN_NODE_1
- SG_ CAN_NODE_THERM_2 m2 : 16|8@1- (1,0) [-128|127] "°C" Vector__XXX
- SG_ CAN_NODE_THERM_1 m2 : 8|8@1- (1,0) [-128|127] "°C" Vector__XXX
+ SG_ CAN_NODE_THERM_2 m2 : 16|8@1- (1,0) [-128|127] "ï¿½C" Vector__XXX
+ SG_ CAN_NODE_THERM_1 m2 : 8|8@1- (1,0) [-128|127] "ï¿½C" Vector__XXX
  SG_ CAN_NODE_PD_9 m1 : 40|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
  SG_ CAN_NODE_PD_8 m1 : 28|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
  SG_ CAN_NODE_PD_7 m1 : 16|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
@@ -74,8 +83,8 @@ BO_ 1537 CAN_NODE_1: 8 CAN_NODE_1
  SG_ CAN_NODE_multiplexor M : 0|4@1+ (1,0) [0|15] "" Vector__XXX
 
 BO_ 1538 CAN_NODE_2: 8 CAN_NODE_2
- SG_ CAN_NODE_THERM_2 m2 : 16|8@1- (1,0) [-128|127] "°C" Vector__XXX
- SG_ CAN_NODE_THERM_1 m2 : 8|8@1- (1,0) [-128|127] "°C" Vector__XXX
+ SG_ CAN_NODE_THERM_2 m2 : 16|8@1- (1,0) [-128|127] "ï¿½C" Vector__XXX
+ SG_ CAN_NODE_THERM_1 m2 : 8|8@1- (1,0) [-128|127] "ï¿½C" Vector__XXX
  SG_ CAN_NODE_PD_9 m1 : 40|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
  SG_ CAN_NODE_PD_8 m1 : 28|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
  SG_ CAN_NODE_PD_7 m1 : 16|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
@@ -89,8 +98,8 @@ BO_ 1538 CAN_NODE_2: 8 CAN_NODE_2
  SG_ CAN_NODE_multiplexor M : 0|4@1+ (1,0) [0|15] "" Vector__XXX
 
 BO_ 1539 CAN_NODE_3: 8 CAN_NODE_3
- SG_ CAN_NODE_THERM_2 m2 : 16|8@1- (1,0) [-128|127] "°C" Vector__XXX
- SG_ CAN_NODE_THERM_1 m2 : 8|8@1- (1,0) [-128|127] "°C" Vector__XXX
+ SG_ CAN_NODE_THERM_2 m2 : 16|8@1- (1,0) [-128|127] "ï¿½C" Vector__XXX
+ SG_ CAN_NODE_THERM_1 m2 : 8|8@1- (1,0) [-128|127] "ï¿½C" Vector__XXX
  SG_ CAN_NODE_PD_9 m1 : 40|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
  SG_ CAN_NODE_PD_8 m1 : 28|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
  SG_ CAN_NODE_PD_7 m1 : 16|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
@@ -104,8 +113,8 @@ BO_ 1539 CAN_NODE_3: 8 CAN_NODE_3
  SG_ CAN_NODE_multiplexor M : 0|4@1+ (1,0) [0|15] "" Vector__XXX
 
 BO_ 1540 CAN_NODE_4: 8 CAN_NODE_4
- SG_ CAN_NODE_THERM_2 m2 : 16|8@1- (1,0) [-128|127] "°C" Vector__XXX
- SG_ CAN_NODE_THERM_1 m2 : 8|8@1- (1,0) [-128|127] "°C" Vector__XXX
+ SG_ CAN_NODE_THERM_2 m2 : 16|8@1- (1,0) [-128|127] "ï¿½C" Vector__XXX
+ SG_ CAN_NODE_THERM_1 m2 : 8|8@1- (1,0) [-128|127] "ï¿½C" Vector__XXX
  SG_ CAN_NODE_PD_9 m1 : 40|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
  SG_ CAN_NODE_PD_8 m1 : 28|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX
  SG_ CAN_NODE_PD_7 m1 : 16|12@1+ (0.00402832,0) [0|16.4959704] "V" Vector__XXX

--- a/dbc/CAN-S.dbc
+++ b/dbc/CAN-S.dbc
@@ -350,6 +350,7 @@ BO_ 256 VCU_Sensors: 8 VCU
  SG_ VCU_APPS : 0|16@1+ (0.1,0) [0|100] "%" Vector__XXX
 
 BO_ 257 VCU_State: 4 VCU
+ SG_ VCU_Power_Saving : 27|1@1- (1,0) [0|1] "" Vector__XXX
  SG_ VCU_Rolling_Counter : 0|16@1+ (1,0) [0|65535] "" Vector__XXX
  SG_ VCU_DRS_Allowed : 26|1@1+ (1,0) [0|1] "" Vector__XXX
  SG_ VCU_DRS_Active : 25|1@1+ (1,0) [0|1] "" Vector__XXX

--- a/out/can_s.c
+++ b/out/can_s.c
@@ -1049,3 +1049,86 @@ bool can_s_vcu_error_vcu_canbc_error_is_in_range(uint8_t value)
 
     return (true);
 }
+
+int can_s_vcu_simulate_init(struct can_s_vcu_simulation_t *msg_p)
+{
+    if (msg_p == NULL) return -1;
+
+    memset(msg_p, 0, sizeof(struct can_s_vcu_simulation_t));
+
+    return 0;
+}
+
+int can_s_vcu_simulation_pack(
+    uint8_t *dst_p,
+    const struct can_s_vcu_simulation_t *src_p,
+    size_t size)
+{
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    memset(&dst_p[0], 0, 8);
+
+    dst_p[0] |= pack_left_shift_u8(src_p->multiplexer, 0u, 0xffu);
+
+    switch (src_p->multiplexer) {
+
+    case 0:
+        dst_p[1] |= pack_left_shift_u16(src_p->sim_apps, 0u, 0xffu);
+        dst_p[2] |= pack_right_shift_u16(src_p->sim_apps, 8u, 0xffu);
+        dst_p[3] |= pack_left_shift_u16(src_p->sim_bps, 0u, 0xffu);
+        dst_p[4] |= pack_right_shift_u16(src_p->sim_bps, 8u, 0xffu);
+        dst_p[5] |= pack_left_shift_u16(src_p->sim_torque_request, 0u, 0xffu);
+        dst_p[6] |= pack_right_shift_u16(src_p->sim_torque_request, 8u, 0xffu);
+        dst_p[7] |= pack_left_shift_u8(src_p->sim_r2_d, 0u, 0x01u);
+        dst_p[7] |= pack_left_shift_u8(src_p->sim_ts_on, 1u, 0x02u);
+        break;
+
+    case 1:
+        dst_p[1] |= pack_left_shift_u16(src_p->sim_power, 0u, 0xffu);
+        dst_p[2] |= pack_right_shift_u16(src_p->sim_power, 8u, 0xffu);
+        break;
+
+    default:
+        break;
+    }
+
+    return (8);
+}
+
+int can_s_vcu_simulation_unpack(
+    struct can_s_vcu_simulation_t *dst_p,
+    const uint8_t *src_p,
+    size_t size)
+{
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    dst_p->multiplexer = unpack_right_shift_u8(src_p[0], 0u, 0xffu);
+
+    switch (dst_p->multiplexer) {
+
+    case 0:
+        dst_p->sim_apps = unpack_right_shift_u16(src_p[1], 0u, 0xffu);
+        dst_p->sim_apps |= unpack_left_shift_u16(src_p[2], 8u, 0xffu);
+        dst_p->sim_bps = unpack_right_shift_u16(src_p[3], 0u, 0xffu);
+        dst_p->sim_bps |= unpack_left_shift_u16(src_p[4], 8u, 0xffu);
+        dst_p->sim_torque_request = unpack_right_shift_u16(src_p[5], 0u, 0xffu);
+        dst_p->sim_torque_request |= unpack_left_shift_u16(src_p[6], 8u, 0xffu);
+        dst_p->sim_r2_d = unpack_right_shift_u8(src_p[7], 0u, 0x01u);
+        dst_p->sim_ts_on = unpack_right_shift_u8(src_p[7], 1u, 0x02u);
+        break;
+
+    case 1:
+        dst_p->sim_power = unpack_right_shift_u16(src_p[1], 0u, 0xffu);
+        dst_p->sim_power |= unpack_left_shift_u16(src_p[2], 8u, 0xffu);
+        break;
+
+    default:
+        break;
+    }
+
+    return (0);
+}

--- a/out/can_s.c
+++ b/out/can_s.c
@@ -939,6 +939,332 @@ int can_s_vcu_error_unpack(
     return (0);
 }
 
+int can_s_msgid_0_x201_pack(
+    uint8_t *dst_p,
+    const struct can_s_msgid_0_x201_t *src_p,
+    size_t size)
+{
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    memset(&dst_p[0], 0, 8);
+
+    dst_p[0] |= pack_right_shift_u16(src_p->bms_pack_current, 8u, 0xffu);
+    dst_p[1] |= pack_left_shift_u16(src_p->bms_pack_current, 0u, 0xffu);
+    dst_p[2] |= pack_right_shift_u16(src_p->bms_pack_inst_voltage, 8u, 0xffu);
+    dst_p[3] |= pack_left_shift_u16(src_p->bms_pack_inst_voltage, 0u, 0xffu);
+    dst_p[4] |= pack_left_shift_u8(src_p->bms_pack_soc, 0u, 0xffu);
+    dst_p[5] |= pack_left_shift_u8(src_p->bms_maximum_pack_voltage, 0u, 0xffu);
+    dst_p[6] |= pack_left_shift_u8(src_p->bms_minimum_pack_voltage, 0u, 0xffu);
+    dst_p[7] |= pack_left_shift_u8(src_p->bms_total_pack_cycles, 0u, 0xffu);
+
+    return (8);
+}
+
+int can_s_msgid_0_x201_unpack(
+    struct can_s_msgid_0_x201_t *dst_p,
+    const uint8_t *src_p,
+    size_t size)
+{
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    dst_p->bms_pack_current = unpack_left_shift_u16(src_p[0], 8u, 0xffu);
+    dst_p->bms_pack_current |= unpack_right_shift_u16(src_p[1], 0u, 0xffu);
+    dst_p->bms_pack_inst_voltage = unpack_left_shift_u16(src_p[2], 8u, 0xffu);
+    dst_p->bms_pack_inst_voltage |= unpack_right_shift_u16(src_p[3], 0u, 0xffu);
+    dst_p->bms_pack_soc = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
+    dst_p->bms_maximum_pack_voltage = unpack_right_shift_u8(src_p[5], 0u, 0xffu);
+    dst_p->bms_minimum_pack_voltage = unpack_right_shift_u8(src_p[6], 0u, 0xffu);
+    dst_p->bms_total_pack_cycles = unpack_right_shift_u8(src_p[7], 0u, 0xffu);
+
+    return (0);
+}
+
+uint16_t can_s_msgid_0_x201_bms_pack_current_encode(double value)
+{
+    return (uint16_t)(value / 0.1);
+}
+
+double can_s_msgid_0_x201_bms_pack_current_decode(uint16_t value)
+{
+    return ((double)value * 0.1);
+}
+
+bool can_s_msgid_0_x201_bms_pack_current_is_in_range(uint16_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint16_t can_s_msgid_0_x201_bms_pack_inst_voltage_encode(double value)
+{
+    return (uint16_t)(value / 0.1);
+}
+
+double can_s_msgid_0_x201_bms_pack_inst_voltage_decode(uint16_t value)
+{
+    return ((double)value * 0.1);
+}
+
+bool can_s_msgid_0_x201_bms_pack_inst_voltage_is_in_range(uint16_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x201_bms_pack_soc_encode(double value)
+{
+    return (uint8_t)(value / 0.5);
+}
+
+double can_s_msgid_0_x201_bms_pack_soc_decode(uint8_t value)
+{
+    return ((double)value * 0.5);
+}
+
+bool can_s_msgid_0_x201_bms_pack_soc_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x201_bms_maximum_pack_voltage_encode(double value)
+{
+    return (uint8_t)(value / 0.1);
+}
+
+double can_s_msgid_0_x201_bms_maximum_pack_voltage_decode(uint8_t value)
+{
+    return ((double)value * 0.1);
+}
+
+bool can_s_msgid_0_x201_bms_maximum_pack_voltage_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x201_bms_minimum_pack_voltage_encode(double value)
+{
+    return (uint8_t)(value / 0.1);
+}
+
+double can_s_msgid_0_x201_bms_minimum_pack_voltage_decode(uint8_t value)
+{
+    return ((double)value * 0.1);
+}
+
+bool can_s_msgid_0_x201_bms_minimum_pack_voltage_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x201_bms_total_pack_cycles_encode(double value)
+{
+    return (uint8_t)(value - 1721.0);
+}
+
+double can_s_msgid_0_x201_bms_total_pack_cycles_decode(uint8_t value)
+{
+    return ((double)value + 1721.0);
+}
+
+bool can_s_msgid_0_x201_bms_total_pack_cycles_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+int can_s_msgid_0_x202_pack(
+    uint8_t *dst_p,
+    const struct can_s_msgid_0_x202_t *src_p,
+    size_t size)
+{
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    memset(&dst_p[0], 0, 8);
+
+    dst_p[0] |= pack_left_shift_u8(src_p->bms_high_temperature, 0u, 0xffu);
+    dst_p[1] |= pack_left_shift_u8(src_p->bms_low_temperature, 0u, 0xffu);
+    dst_p[2] |= pack_left_shift_u8(src_p->bms_average_temperature, 0u, 0xffu);
+    dst_p[3] |= pack_left_shift_u8(src_p->bms_internal_temperature, 0u, 0xffu);
+    dst_p[4] |= pack_left_shift_u8(src_p->bms_high_thermistor_id, 0u, 0xffu);
+    dst_p[5] |= pack_left_shift_u8(src_p->bms_low_thermistor_id, 0u, 0xffu);
+    dst_p[6] |= pack_left_shift_u8(src_p->bms_maximum_cell_voltage, 0u, 0xffu);
+    dst_p[7] |= pack_left_shift_u8(src_p->bms_minimum_cell_voltage, 0u, 0xffu);
+
+    return (8);
+}
+
+int can_s_msgid_0_x202_unpack(
+    struct can_s_msgid_0_x202_t *dst_p,
+    const uint8_t *src_p,
+    size_t size)
+{
+    if (size < 8u) {
+        return (-EINVAL);
+    }
+
+    dst_p->bms_high_temperature = unpack_right_shift_u8(src_p[0], 0u, 0xffu);
+    dst_p->bms_low_temperature = unpack_right_shift_u8(src_p[1], 0u, 0xffu);
+    dst_p->bms_average_temperature = unpack_right_shift_u8(src_p[2], 0u, 0xffu);
+    dst_p->bms_internal_temperature = unpack_right_shift_u8(src_p[3], 0u, 0xffu);
+    dst_p->bms_high_thermistor_id = unpack_right_shift_u8(src_p[4], 0u, 0xffu);
+    dst_p->bms_low_thermistor_id = unpack_right_shift_u8(src_p[5], 0u, 0xffu);
+    dst_p->bms_maximum_cell_voltage = unpack_right_shift_u8(src_p[6], 0u, 0xffu);
+    dst_p->bms_minimum_cell_voltage = unpack_right_shift_u8(src_p[7], 0u, 0xffu);
+
+    return (0);
+}
+
+uint8_t can_s_msgid_0_x202_bms_high_temperature_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double can_s_msgid_0_x202_bms_high_temperature_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool can_s_msgid_0_x202_bms_high_temperature_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x202_bms_low_temperature_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double can_s_msgid_0_x202_bms_low_temperature_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool can_s_msgid_0_x202_bms_low_temperature_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x202_bms_average_temperature_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double can_s_msgid_0_x202_bms_average_temperature_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool can_s_msgid_0_x202_bms_average_temperature_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x202_bms_internal_temperature_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double can_s_msgid_0_x202_bms_internal_temperature_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool can_s_msgid_0_x202_bms_internal_temperature_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x202_bms_high_thermistor_id_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double can_s_msgid_0_x202_bms_high_thermistor_id_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool can_s_msgid_0_x202_bms_high_thermistor_id_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x202_bms_low_thermistor_id_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double can_s_msgid_0_x202_bms_low_thermistor_id_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool can_s_msgid_0_x202_bms_low_thermistor_id_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x202_bms_maximum_cell_voltage_encode(double value)
+{
+    return (uint8_t)(value / 0.0001);
+}
+
+double can_s_msgid_0_x202_bms_maximum_cell_voltage_decode(uint8_t value)
+{
+    return ((double)value * 0.0001);
+}
+
+bool can_s_msgid_0_x202_bms_maximum_cell_voltage_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
+uint8_t can_s_msgid_0_x202_bms_minimum_cell_voltage_encode(double value)
+{
+    return (uint8_t)(value / 0.0001);
+}
+
+double can_s_msgid_0_x202_bms_minimum_cell_voltage_decode(uint8_t value)
+{
+    return ((double)value * 0.0001);
+}
+
+bool can_s_msgid_0_x202_bms_minimum_cell_voltage_is_in_range(uint8_t value)
+{
+    (void)value;
+
+    return (true);
+}
+
 int can_s_vcu_error_init(struct can_s_vcu_error_t *msg_p)
 {
     if (msg_p == NULL) return -1;

--- a/out/can_s.c
+++ b/out/can_s.c
@@ -771,6 +771,7 @@ int can_s_vcu_state_pack(
     dst_p[3] |= pack_left_shift_u8(src_p->vcu_r2_d, 0u, 0x01u);
     dst_p[3] |= pack_left_shift_u8(src_p->vcu_drs_active, 1u, 0x02u);
     dst_p[3] |= pack_left_shift_u8(src_p->vcu_drs_allowed, 2u, 0x04u);
+    dst_p[3] |= pack_left_shift_u8(src_p->vcu_power_saving, 3u, 0x08u);
 
     return (4);
 }
@@ -790,6 +791,7 @@ int can_s_vcu_state_unpack(
     dst_p->vcu_r2_d = unpack_right_shift_u8(src_p[3], 0u, 0x01u);
     dst_p->vcu_drs_active = unpack_right_shift_u8(src_p[3], 1u, 0x02u);
     dst_p->vcu_drs_allowed = unpack_right_shift_u8(src_p[3], 2u, 0x04u);
+    dst_p->vcu_power_saving = unpack_right_shift_u8(src_p[3], 3u, 0x08u);
 
     return (0);
 }
@@ -878,6 +880,21 @@ double can_s_vcu_state_vcu_drs_allowed_decode(uint8_t value)
 }
 
 bool can_s_vcu_state_vcu_drs_allowed_is_in_range(uint8_t value)
+{
+    return (value <= 1u);
+}
+
+uint8_t can_s_vcu_state_vcu_power_saving_encode(double value)
+{
+    return (uint8_t)(value);
+}
+
+double can_s_vcu_state_vcu_power_saving_decode(uint8_t value)
+{
+    return ((double)value);
+}
+
+bool can_s_vcu_state_vcu_power_saving_is_in_range(uint8_t value)
 {
     return (value <= 1u);
 }

--- a/out/can_s.h
+++ b/out/can_s.h
@@ -54,6 +54,7 @@ extern "C" {
 #define CAN_S_VCU_STATE_FRAME_ID (0x101u)
 #define CAN_S_VCU_ERROR_FRAME_ID (0x102u)
 #define CAN_S_VCU_TEMPS_FRAME_ID (0x105u)
+#define CAN_S_VCU_SIMULATION_FRAME_ID (0x106u)
 
 /* Frame lengths in bytes. */
 #define CAN_S_OCT_GPS_STATS_LENGTH (8u)
@@ -66,6 +67,7 @@ extern "C" {
 #define CAN_S_VCU_STATE_LENGTH (4u)
 #define CAN_S_VCU_TEMPS_LENGTH (8u)
 #define CAN_S_VCU_ERROR_LENGTH (6u)
+#define CAN_S_VCU_SIMULATION_LENGTH (8u)
 
 /* Extended or standard frame types. */
 #define CAN_S_OCT_GPS_STATS_IS_EXTENDED (0)
@@ -78,6 +80,7 @@ extern "C" {
 #define CAN_S_VCU_STATE_IS_EXTENDED (0)
 #define CAN_S_VCU_TEMPS_IS_EXTENDED (0)
 #define CAN_S_VCU_ERROR_IS_EXTENDED (0)
+#define CAN_S_VCU_SIMULATION_IS_EXTENDED (0)
 
 /* Frame cycle times in milliseconds. */
 
@@ -96,6 +99,7 @@ extern "C" {
 #define CAN_S_VCU_STATE_NAME "VCU_State"
 #define CAN_S_VCU_ERROR_NAME "VCU_Error"
 #define CAN_S_VCU_TEMPS_NAME "VCU_Temps"
+#define CAN_S_VCU_SIMULATION_NAME "VCU_Simulation"
 
 /* Signal Names. */
 #define CAN_S_OCT_GPS_STATS_OCT_GPS_TIME_UCT_NAME "OCT_GPS_TimeUCT"
@@ -126,6 +130,12 @@ extern "C" {
 #define CAN_S_VCU_ERROR_VCU_RTCAN1_ERROR_NAME "VCU_RTCAN1_Error"
 #define CAN_S_VCU_ERROR_VCU_RTCAN2_ERROR_NAME "VCU_RTCAN2_Error"
 #define CAN_S_VCU_ERROR_VCU_CANBC_ERROR_NAME "VCU_CANBC_Error"
+#define CAN_S_VCU_SIMULATION_VCU_SIM_TORQUE_REQUEST_NAME "VCU_Sim_Torque_Request"
+#define CAN_S_VCU_SIMULATION_VCU_SIM_POWER_NAME "VCU_Sim_Power"
+#define CAN_S_VCU_SIMULATION_VCU_SIM_R2D_NAME "VCU_Sim_R2D"
+#define CAN_S_VCU_SIMULATION_VCU_SIM_TS_ON_NAME "VCU_Sim_TS_ON"
+#define CAN_S_VCU_SIMULATION_VCU_SIM_APPS_NAME "VCU_Sim_APPS"
+#define CAN_S_VCU_SIMULATION_VCU_SIM_BPS_NAME "VCU_Sim_BPS"
 
 /**
  * Signals in message OCT_GPS_Stats.
@@ -415,6 +425,23 @@ struct can_s_vcu_error_t {
      * Offset: 0
      */
     uint8_t vcu_canbc_error;
+};
+
+struct can_s_vcu_simulation_t
+{
+    uint8_t multiplexer;
+
+    uint16_t sim_power;
+
+    uint16_t sim_torque_request;
+
+    uint8_t sim_r2_d;
+
+    uint8_t sim_ts_on;
+
+    uint16_t sim_apps;
+
+    uint16_t sim_bps;
 };
 
 /**
@@ -1570,6 +1597,17 @@ double can_s_vcu_error_vcu_canbc_error_decode(uint8_t value);
  */
 bool can_s_vcu_error_vcu_canbc_error_is_in_range(uint8_t value);
 
+int can_s_vcu_simulation_unpack(
+    struct can_s_vcu_simulation_t *dst_p,
+    const uint8_t *src_p,
+    size_t size);
+
+int can_s_vcu_simulation_pack(
+    uint8_t *dst_p,
+    const struct can_s_vcu_simulation_t *src_p,
+    size_t size);
+
+int can_s_vcu_simulate_init(struct can_s_vcu_simulation_t *msg_p);
 
 #ifdef __cplusplus
 }

--- a/out/can_s.h
+++ b/out/can_s.h
@@ -350,6 +350,13 @@ struct can_s_vcu_state_t {
      * Offset: 0
      */
     uint8_t vcu_drs_allowed;
+
+    /**
+     * Range: 0..1 (0..1 -)
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t vcu_power_saving;
 };
 
 struct can_s_vcu_temps_t {
@@ -1336,6 +1343,33 @@ double can_s_vcu_state_vcu_drs_allowed_decode(uint8_t value);
  * @return true if in range, false otherwise.
  */
 bool can_s_vcu_state_vcu_drs_allowed_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_vcu_state_vcu_power_saving_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_vcu_state_vcu_power_saving_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_vcu_state_vcu_power_saving_is_in_range(uint8_t value);
 
 /**
  * Pack message VCU_Error.

--- a/out/can_s.h
+++ b/out/can_s.h
@@ -54,6 +54,8 @@ extern "C" {
 #define CAN_S_VCU_STATE_FRAME_ID (0x101u)
 #define CAN_S_VCU_ERROR_FRAME_ID (0x102u)
 #define CAN_S_VCU_TEMPS_FRAME_ID (0x105u)
+#define CAN_S_MSGID_0_X201_FRAME_ID (0x201u)
+#define CAN_S_MSGID_0_X202_FRAME_ID (0x202u)
 #define CAN_S_VCU_SIMULATION_FRAME_ID (0x106u)
 
 /* Frame lengths in bytes. */
@@ -442,6 +444,122 @@ struct can_s_vcu_simulation_t
     uint16_t sim_apps;
 
     uint16_t sim_bps;
+};
+
+/**
+ * Signals in message MSGID_0X201.
+ *
+ * This ID Transmits at 8 ms.
+ *
+ * All signal values are as on the CAN bus.
+ */
+struct can_s_msgid_0_x201_t {
+    /**
+     * Range: -
+     * Scale: 0.1
+     * Offset: 0
+     */
+    uint16_t bms_pack_current;
+
+    /**
+     * Range: -
+     * Scale: 0.1
+     * Offset: 0
+     */
+    uint16_t bms_pack_inst_voltage;
+
+    /**
+     * Range: -
+     * Scale: 0.5
+     * Offset: 0
+     */
+    uint8_t bms_pack_soc;
+
+    /**
+     * Range: -
+     * Scale: 0.1
+     * Offset: 0
+     */
+    uint8_t bms_maximum_pack_voltage;
+
+    /**
+     * Range: -
+     * Scale: 0.1
+     * Offset: 0
+     */
+    uint8_t bms_minimum_pack_voltage;
+
+    /**
+     * Range: -
+     * Scale: 1
+     * Offset: 1721
+     */
+    uint8_t bms_total_pack_cycles;
+};
+
+/**
+ * Signals in message MSGID_0X202.
+ *
+ * This ID Transmits at 8 ms.
+ *
+ * All signal values are as on the CAN bus.
+ */
+struct can_s_msgid_0_x202_t {
+    /**
+     * Range: -
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t bms_high_temperature;
+
+    /**
+     * Range: -
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t bms_low_temperature;
+
+    /**
+     * Range: -
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t bms_average_temperature;
+
+    /**
+     * Range: -
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t bms_internal_temperature;
+
+    /**
+     * Range: -
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t bms_high_thermistor_id;
+
+    /**
+     * Range: -
+     * Scale: 1
+     * Offset: 0
+     */
+    uint8_t bms_low_thermistor_id;
+
+    /**
+     * Range: -
+     * Scale: 0.0001
+     * Offset: 0
+     */
+    uint8_t bms_maximum_cell_voltage;
+
+    /**
+     * Range: -
+     * Scale: 0.0001
+     * Offset: 0
+     */
+    uint8_t bms_minimum_cell_voltage;
 };
 
 /**
@@ -1596,6 +1714,440 @@ double can_s_vcu_error_vcu_canbc_error_decode(uint8_t value);
  * @return true if in range, false otherwise.
  */
 bool can_s_vcu_error_vcu_canbc_error_is_in_range(uint8_t value);
+
+/**
+ * Pack message MSGID_0X201.
+ *
+ * @param[out] dst_p Buffer to pack the message into.
+ * @param[in] src_p Data to pack.
+ * @param[in] size Size of dst_p.
+ *
+ * @return Size of packed data, or negative error code.
+ */
+int can_s_msgid_0_x201_pack(
+    uint8_t *dst_p,
+    const struct can_s_msgid_0_x201_t *src_p,
+    size_t size);
+
+/**
+ * Unpack message MSGID_0X201.
+ *
+ * @param[out] dst_p Object to unpack the message into.
+ * @param[in] src_p Message to unpack.
+ * @param[in] size Size of src_p.
+ *
+ * @return zero(0) or negative error code.
+ */
+int can_s_msgid_0_x201_unpack(
+    struct can_s_msgid_0_x201_t *dst_p,
+    const uint8_t *src_p,
+    size_t size);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint16_t can_s_msgid_0_x201_bms_pack_current_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x201_bms_pack_current_decode(uint16_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x201_bms_pack_current_is_in_range(uint16_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint16_t can_s_msgid_0_x201_bms_pack_inst_voltage_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x201_bms_pack_inst_voltage_decode(uint16_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x201_bms_pack_inst_voltage_is_in_range(uint16_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x201_bms_pack_soc_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x201_bms_pack_soc_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x201_bms_pack_soc_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x201_bms_maximum_pack_voltage_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x201_bms_maximum_pack_voltage_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x201_bms_maximum_pack_voltage_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x201_bms_minimum_pack_voltage_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x201_bms_minimum_pack_voltage_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x201_bms_minimum_pack_voltage_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x201_bms_total_pack_cycles_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x201_bms_total_pack_cycles_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x201_bms_total_pack_cycles_is_in_range(uint8_t value);
+
+/**
+ * Pack message MSGID_0X202.
+ *
+ * @param[out] dst_p Buffer to pack the message into.
+ * @param[in] src_p Data to pack.
+ * @param[in] size Size of dst_p.
+ *
+ * @return Size of packed data, or negative error code.
+ */
+int can_s_msgid_0_x202_pack(
+    uint8_t *dst_p,
+    const struct can_s_msgid_0_x202_t *src_p,
+    size_t size);
+
+/**
+ * Unpack message MSGID_0X202.
+ *
+ * @param[out] dst_p Object to unpack the message into.
+ * @param[in] src_p Message to unpack.
+ * @param[in] size Size of src_p.
+ *
+ * @return zero(0) or negative error code.
+ */
+int can_s_msgid_0_x202_unpack(
+    struct can_s_msgid_0_x202_t *dst_p,
+    const uint8_t *src_p,
+    size_t size);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x202_bms_high_temperature_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x202_bms_high_temperature_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x202_bms_high_temperature_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x202_bms_low_temperature_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x202_bms_low_temperature_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x202_bms_low_temperature_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x202_bms_average_temperature_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x202_bms_average_temperature_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x202_bms_average_temperature_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x202_bms_internal_temperature_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x202_bms_internal_temperature_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x202_bms_internal_temperature_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x202_bms_high_thermistor_id_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x202_bms_high_thermistor_id_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x202_bms_high_thermistor_id_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x202_bms_low_thermistor_id_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x202_bms_low_thermistor_id_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x202_bms_low_thermistor_id_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x202_bms_maximum_cell_voltage_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x202_bms_maximum_cell_voltage_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x202_bms_maximum_cell_voltage_is_in_range(uint8_t value);
+
+/**
+ * Encode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to encode.
+ *
+ * @return Encoded signal.
+ */
+uint8_t can_s_msgid_0_x202_bms_minimum_cell_voltage_encode(double value);
+
+/**
+ * Decode given signal by applying scaling and offset.
+ *
+ * @param[in] value Signal to decode.
+ *
+ * @return Decoded signal.
+ */
+double can_s_msgid_0_x202_bms_minimum_cell_voltage_decode(uint8_t value);
+
+/**
+ * Check that given signal is in allowed range.
+ *
+ * @param[in] value Signal to check.
+ *
+ * @return true if in range, false otherwise.
+ */
+bool can_s_msgid_0_x202_bms_minimum_cell_voltage_is_in_range(uint8_t value);
 
 int can_s_vcu_simulation_unpack(
     struct can_s_vcu_simulation_t *dst_p,


### PR DESCRIPTION
### Changes

- Added VCU_Power_Saving to VCU_State on CAN-S

### Fixed Issue(s)

Closes [#35](https://github.com/sufst/can-defs/issues/35)

### Checklist

- [x] Schemas are generated with no errors.
- [x] ~`/out` folder has not been changed, or~ this is a new release.
- [x] If modified, the DBC file(s) can be opened in Vector CANdb++ without issue.
